### PR TITLE
updated quill to 2.0.0-dev.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5665,9 +5665,9 @@
       "dev": true
     },
     "eventemitter3": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-2.0.3.tgz",
-      "integrity": "sha1-teEHm1n7XhuidxwKmTvgYKWMmbo="
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.2.tgz",
+      "integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q=="
     },
     "events": {
       "version": "3.1.0",
@@ -6010,9 +6010,9 @@
       "dev": true
     },
     "fast-diff": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.1.2.tgz",
-      "integrity": "sha512-KaJUt+M9t1qaIteSvjc6P3RbMdXsNhK61GRftR6SNxqmhthcd9MGIi4T+o0jD8LUSpSnSKXE20nLtJ3fOHxQig=="
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.2.0.tgz",
+      "integrity": "sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w=="
     },
     "fast-glob": {
       "version": "3.1.1",
@@ -9735,9 +9735,9 @@
       }
     },
     "parchment": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/parchment/-/parchment-1.1.4.tgz",
-      "integrity": "sha512-J5FBQt/pM2inLzg4hEWmzQx/8h8D0CiDxaG3vyp9rKrQRSDgBlhjdP5jQGgosEajXPSQouXGHOmVdgo7QmJuOg=="
+      "version": "2.0.0-dev.0",
+      "resolved": "https://registry.npmjs.org/parchment/-/parchment-2.0.0-dev.0.tgz",
+      "integrity": "sha512-andCgmOy3jFa3GWfp1sPi+1u5Y6Seis6NmKyF1QdbZ3ozn3Evd/oidDqv2il4kZ/Bt/IBiWzqRaM/BVDIeO+Mg=="
     },
     "parent-module": {
       "version": "1.0.1",
@@ -10938,26 +10938,26 @@
       "dev": true
     },
     "quill": {
-      "version": "1.3.7",
-      "resolved": "https://registry.npmjs.org/quill/-/quill-1.3.7.tgz",
-      "integrity": "sha512-hG/DVzh/TiknWtE6QmWAF/pxoZKYxfe3J/d/+ShUWkDvvkZQVTPeVmUJVu1uE6DDooC4fWTiCLh84ul89oNz5g==",
+      "version": "2.0.0-dev.3",
+      "resolved": "https://registry.npmjs.org/quill/-/quill-2.0.0-dev.3.tgz",
+      "integrity": "sha512-FiHFpgaHaOyPjuywLBjrHal6RS1gWHoIO9dFUE2ll46Nb0xFDEulHdiFRTPPifrE1HUmAFXJIL3iJjukD+eUEQ==",
       "requires": {
-        "clone": "^2.1.1",
+        "clone": "^2.1.2",
         "deep-equal": "^1.0.1",
-        "eventemitter3": "^2.0.3",
+        "eventemitter3": "^3.1.0",
         "extend": "^3.0.2",
-        "parchment": "^1.1.4",
-        "quill-delta": "^3.6.2"
+        "parchment": "2.0.0-dev.0",
+        "quill-delta": "4.1.0"
       }
     },
     "quill-delta": {
-      "version": "3.6.3",
-      "resolved": "https://registry.npmjs.org/quill-delta/-/quill-delta-3.6.3.tgz",
-      "integrity": "sha512-wdIGBlcX13tCHOXGMVnnTVFtGRLoP0imqxM696fIPwIf5ODIYUHIvHbZcyvGlZFiFhK5XzDC2lpjbxRhnM05Tg==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/quill-delta/-/quill-delta-4.1.0.tgz",
+      "integrity": "sha512-GQi04cJRnGcUR3fN8ChjfJGdnCF297BVTb4kEgnlewiyu/PRnWZDchmiJoc9Whq+ZwHgbUbcVgrbGU/dQgOVFw==",
       "requires": {
         "deep-equal": "^1.0.1",
         "extend": "^3.0.2",
-        "fast-diff": "1.1.2"
+        "fast-diff": "1.2.0"
       }
     },
     "randomatic": {

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@angular/platform-browser": "^9.0.0",
     "@angular/platform-browser-dynamic": "^9.0.0",
     "core-js": "^3.6.0",
-    "quill": "^1.3.0",
+    "quill": "^2.0.0-dev.3",
     "rxjs": "^6.5.0",
     "zone.js": "^0.10.0"
   },

--- a/projects/lib/package.json
+++ b/projects/lib/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/zefoy/ngx-quill-wrapper.git"
   },
   "dependencies": {
-    "quill": "^1.3.0"
+    "quill": "^2.0.0-dev.3"
   },
   "peerDependencies": {
     "@angular/common": "^9.0.0",


### PR DESCRIPTION
Hi!

I have updated *quill* version to 2.0.0-dev.3 which is still under development and is published in npm as a "dev" package. Could we publish a new "dev" package of *ngx-quill-wrapper* using this new quill version? We need it to try to fix our Angular UI tests with *jest*.

After the update, I have tested the example app and it seems works fine.

Thanks so much!